### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1](https://github.com/mathematic-inc/addr-spec-rs/compare/v0.6.0...0.6.1) (2023-01-28)
+
+
+### Performance Improvements
+
+* Use memchr ([#8](https://github.com/mathematic-inc/addr-spec-rs/issues/8)) ([2337137](https://github.com/mathematic-inc/addr-spec-rs/commit/2337137e5e5aefe10706d374d888fa08e4e4a243))
+
 ## [0.6.0](https://github.com/mathematic-inc/addr-spec-rs/commits/v0.6.0) (2023-01-24)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "addr-spec"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "icu_collections",
  "icu_datagen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addr-spec"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A wicked fast UTF-8 email address parser and serializer."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Here is a summary of this release.
---


## [0.6.1](https://github.com/mathematic-inc/addr-spec-rs/compare/v0.6.0...0.6.1) (2023-01-28)


### Performance Improvements

* Use memchr ([#8](https://github.com/mathematic-inc/addr-spec-rs/issues/8)) ([2337137](https://github.com/mathematic-inc/addr-spec-rs/commit/2337137e5e5aefe10706d374d888fa08e4e4a243))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).