### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 * Use memchr ([#8](https://github.com/mathematic-inc/addr-spec-rs/issues/8)) ([2337137](https://github.com/mathematic-inc/addr-spec-rs/commit/2337137e5e5aefe10706d374d888fa08e4e4a243))
 
+## [0.6.1](https://github.com/mathematic-inc/addr-spec-rs/compare/v0.6.1...0.6.1) (2023-01-28)
+
+
+### Performance Improvements
+
+* Use memchr ([#8](https://github.com/mathematic-inc/addr-spec-rs/issues/8)) ([2337137](https://github.com/mathematic-inc/addr-spec-rs/commit/2337137e5e5aefe10706d374d888fa08e4e4a243))
+
 ## [0.6.0](https://github.com/mathematic-inc/addr-spec-rs/commits/v0.6.0) (2023-01-24)
 
 


### PR DESCRIPTION
Here is a summary of this release.
---


## [0.6.1](https://github.com/mathematic-inc/addr-spec-rs/compare/v0.6.1...0.6.1) (2023-01-28)


### Performance Improvements

* Use memchr ([#8](https://github.com/mathematic-inc/addr-spec-rs/issues/8)) ([2337137](https://github.com/mathematic-inc/addr-spec-rs/commit/2337137e5e5aefe10706d374d888fa08e4e4a243))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).