### PR TITLE
perf: implement ASCII escape using macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,6 @@ dependencies = [
  "icu_datagen",
  "icu_normalizer",
  "icu_provider",
- "memchr",
  "regex",
  "rustc_version 0.4.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ zerovec = { version = "0.9.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 email_address = { version = "0.2.4", optional = true }
 
-memchr = "2.5.0"
-
 [dev-dependencies]
 regex = "1.7.1"
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,38 +1,48 @@
-use std::alloc::{alloc, Layout};
-
-fn memcspn(value: &[u8], accept: &[u8]) -> Option<usize> {
-    let mut i = 0;
-    while i < value.len() {
-        if memchr::memchr(value[i], accept).is_some() {
-            return Some(i);
+macro_rules! memcpsn {
+    ($value:ident, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
+        {
+            let mut i = 0;
+            loop {
+                if i == $value.len() {
+                    break None;
+                }
+                if matches!($value[i], $( $pattern )|+ $( if $guard )?) {
+                    break Some(i);
+                }
+                i += 1;
+            }
         }
-        i += 1;
-    }
-    None
+    };
 }
 
-/// Escape ASCII characters in the given string. The first character in `cntl_chrs`
-/// is used as the escape character.
-pub fn escape<const N: usize>(value: &str, escape: [u8; N]) -> String {
-    let cap = value.len() << 1;
-    unsafe {
-        let buffer = alloc(Layout::array::<u8>(cap).unwrap());
-        let mut src = value.as_bytes();
-        let mut dst = buffer;
-        while let Some(end) = memcspn(src, &escape) {
-            dst.copy_from_nonoverlapping(src.as_ptr(), end);
-            dst = dst.add(end);
-            dst.copy_from_nonoverlapping([escape[0], src[end]].as_ptr(), 2);
-            dst = dst.add(2);
-            src = &src[end + 1..];
+pub(crate) use memcpsn;
+
+macro_rules! escape {
+    ($expression:expr, $escape_char:literal, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
+        {
+            let cap = $expression.len() << 1;
+            unsafe {
+                let buffer = std::alloc::alloc(std::alloc::Layout::array::<u8>(cap).unwrap());
+                let mut src = $expression.as_bytes();
+                let mut dst = buffer;
+                while let Some(end) = $crate::ascii::memcpsn!(src, $escape_char | $( $pattern )|+ $( if $guard )?) {
+                    dst.copy_from_nonoverlapping(src.as_ptr(), end);
+                    dst = dst.add(end);
+                    dst.copy_from_nonoverlapping([$escape_char, src[end]].as_ptr(), 2);
+                    dst = dst.add(2);
+                    src = &src[end + 1..];
+                }
+                if !src.is_empty() {
+                    dst.copy_from_nonoverlapping(src.as_ptr(), src.len());
+                    dst = dst.add(src.len());
+                }
+                String::from_raw_parts(buffer, dst.offset_from(buffer) as usize, cap)
+            }
         }
-        if !src.is_empty() {
-            dst.copy_from_nonoverlapping(src.as_ptr(), src.len());
-            dst = dst.add(src.len());
-        }
-        String::from_raw_parts(buffer, dst.offset_from(buffer) as usize, cap)
-    }
+    };
 }
+
+pub(crate) use escape;
 
 #[cfg(test)]
 mod tests {
@@ -40,13 +50,13 @@ mod tests {
 
     #[test]
     fn test_escape() {
-        assert_eq!(escape("", [b'\\', b'"']), "");
-        assert_eq!(escape("abc", [b'\\', b'"']), "abc");
-        assert_eq!(escape("a\\b", [b'\\', b'"']), "a\\\\b");
-        assert_eq!(escape("a\"b", [b'\\', b'"']), "a\\\"b");
-        assert_eq!(escape("a\\\"b", [b'\\', b'"']), "a\\\\\\\"b");
-        assert_eq!(escape("😄\"😄😄", [b'\\', b'"']), "😄\\\"😄😄");
-        assert_eq!(escape("😄😄😄\"", [b'\\', b'"']), "😄😄😄\\\"");
+        assert_eq!(escape!("", b'\\', b'"'), "");
+        assert_eq!(escape!("abc", b'\\', b'"'), "abc");
+        assert_eq!(escape!("a\\b", b'\\', b'"'), "a\\\\b");
+        assert_eq!(escape!("a\"b", b'\\', b'"'), "a\\\"b");
+        assert_eq!(escape!("a\\\"b", b'\\', b'"'), "a\\\\\\\"b");
+        assert_eq!(escape!("😄\"😄😄", b'\\', b'"'), "😄\\\"😄😄");
+        assert_eq!(escape!("😄😄😄\"", b'\\', b'"'), "😄😄😄\\\"");
     }
 }
 
@@ -59,42 +69,42 @@ mod benches {
     #[bench]
     fn bench_no_escape_small(b: &mut test::Bencher) {
         let s = "abc";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 
     #[bench]
     fn bench_no_escape_medium(b: &mut test::Bencher) {
         let s = "abcdefghijklmnopqrstuvwxyz";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 
     #[bench]
     fn bench_no_escape_large(b: &mut test::Bencher) {
         let s = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 
     #[bench]
     fn bench_escape_small(b: &mut test::Bencher) {
         let s = "a\\b";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 
     #[bench]
     fn bench_escape_medium(b: &mut test::Bencher) {
         let s = "a\\bcdefgh\\ijklmnopqrst\\uvwxyz";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 
     #[bench]
     fn bench_escape_large(b: &mut test::Bencher) {
         let s = "a\\bcdefgh\\ijklmnopqrst\\uvwxyzabcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz\\abcdefghijklmnopqrstuvwxyz";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 
     #[bench]
     fn bench_many_escapes(b: &mut test::Bencher) {
         let s = "\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"";
-        b.iter(|| escape(s, [b'\\', b'"']));
+        b.iter(|| escape!(s, b'\\', b'"'));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,8 @@ use std::{
 pub use parser::ParseError;
 use parser::{is_ascii_control_and_not_htab, is_not_atext, is_not_dtext, Parser};
 
-#[inline]
 fn quote(value: &str) -> String {
-    ascii::escape(value, [b'\\', b'"', b' ', b'\t'])
+    ascii::escape!(value, b'\\', b'"' | b' ' | b'\t')
 }
 
 /// Address specification as defined in [RFC

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,16 +15,16 @@ pub const fn is_ascii_control_or_space(chr: char) -> bool {
 
 #[inline]
 pub const fn is_not_atext(chr: char) -> bool {
-    chr.is_ascii_control()
+    is_ascii_control_or_space(chr)
         || matches!(
             chr,
-            ' ' | '"' | '(' | ')' | ',' | ':' | '<' | '>' | '@' | '[' | ']' | '\\'
+            '"' | '(' | ')' | ',' | ':' | '<' | '>' | '@' | '[' | ']' | '\\'
         )
 }
 
 #[inline]
 pub const fn is_not_dtext(chr: char) -> bool {
-    chr.is_ascii_control() || matches!(chr, ' ' | '[' | ']' | '\\')
+    is_ascii_control_or_space(chr) || matches!(chr, '[' | ']' | '\\')
 }
 
 /// A error that can occur when parsing or creating an address specification.


### PR DESCRIPTION
This PR implements escapes using macros. More precisely, we are choosing to have the compiler optimize out the escape procedure rather than manually embedding the optimizations. This also has the advantage of removing a dependency.