### PR TITLE
Migrate Claude actions to Codex

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -14,22 +14,21 @@ concurrency:
 
 jobs:
   enhance:
-    name: Enhance release notes with Claude
+    name: Enhance release notes with Codex
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+      - name: Write release notes with Codex
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          permission-profile: ":workspace"
           prompt: |
             Write an exciting, polished GitHub release body for addr-spec ${{ inputs.tag }} and save it to `release-notes.md`.
 


### PR DESCRIPTION
## Summary

- Replace the Claude Code release-note step with the pinned Codex GitHub Action.
- Use the `:workspace` permission profile and the `OPENAI_API_KEY` secret.
- Remove the no-longer-needed OIDC permission.

## Validation

- `actionlint` on the changed workflow
- YAML parse and `git diff --check`

## Required setup

Add the `OPENAI_API_KEY` organization secret before merging; it is not currently configured.