### PR TITLE
Add `no_std` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,7 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Test
         run: cargo test
+      - name: Test no_std build
+        run: |
+          rustup target add thumbv6m-none-eabi
+          cargo build --verbose --release --target thumbv6m-none-eabi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,6 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,13 @@ white-spaces = []
 nightly = []
 
 [dependencies]
-unicode-normalization = { version = "0.1.23", optional = true }
+unicode-normalization = { version = "0.1.23", optional = true, default-features = false }
 
-serde = { version = "1.0.217", optional = true, features = ["derive"] }
-email_address = { version = "0.2.4", optional = true }
+serde = { version = "1.0.217", optional = true, default-features = false, features = [
+  "alloc",
+  "derive",
+] }
+email_address = { version = "0.2.4", optional = true, default-features = false }
 
 [dev-dependencies]
 regex = "1.10.4"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A wicked fast UTF-8 email address parser and serializer. It provides
   5322](https://www.rfc-editor.org/rfc/rfc5322#section-3.4.1) and [Section 3.2,
   RFC 6532](https://datatracker.ietf.org/doc/html/rfc6532#section-3.2) with
   position-accurate errors.
+- [`no_std`](https://docs.rust-embedded.org/book/intro/no-std.html) support
 
 ## Features
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -20,7 +20,7 @@ macro_rules! escape {
         {
             let cap = $expression.len() << 1;
             unsafe {
-                let buffer = std::alloc::alloc(std::alloc::Layout::array::<u8>(cap).unwrap());
+                let buffer = ::alloc::alloc::alloc(::core::alloc::Layout::array::<u8>(cap).unwrap());
                 let mut src = $expression.as_bytes();
                 let mut dst = buffer;
                 while let Some(end) = $crate::ascii::memcpsn!(src, $escape_char | $( $pattern )|+ $( if $guard )?) {
@@ -34,7 +34,7 @@ macro_rules! escape {
                     dst.copy_from_nonoverlapping(src.as_ptr(), src.len());
                     dst = dst.add(src.len());
                 }
-                String::from_raw_parts(buffer, dst.offset_from(buffer) as usize, cap)
+                ::alloc::string::String::from_raw_parts(buffer, dst.offset_from(buffer) as usize, cap)
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,16 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(feature = "nightly", feature(test))]
+#![no_std]
+
+extern crate alloc;
+extern crate core;
 
 mod ascii;
 mod parser;
 mod unicode;
 
-use std::{
+use alloc::string::{String, ToString};
+use core::{
     fmt::{self, Write},
     str::FromStr,
 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
-use std::{error::Error, fmt, mem::ManuallyDrop, str::Chars};
+use alloc::string::String;
+use core::{error::Error, fmt, mem::ManuallyDrop, str::Chars};
 
 use super::unicode;
 use super::AddrSpec;
@@ -332,7 +333,9 @@ pub struct FixedVec<T> {
 impl<T> FixedVec<T> {
     pub unsafe fn new(cap: usize) -> Self {
         Self {
-            ptr: unsafe { std::alloc::alloc(std::alloc::Layout::array::<T>(cap).unwrap()).cast() },
+            ptr: unsafe {
+                alloc::alloc::alloc(alloc::alloc::Layout::array::<T>(cap).unwrap()).cast()
+            },
             len: 0,
             cap,
         }
@@ -340,7 +343,7 @@ impl<T> FixedVec<T> {
 
     unsafe fn extend_unchecked(&mut self, slice: &[T]) {
         unsafe {
-            std::ptr::copy_nonoverlapping(slice.as_ptr(), self.ptr.add(self.len), slice.len());
+            core::ptr::copy_nonoverlapping(slice.as_ptr(), self.ptr.add(self.len), slice.len());
         }
         self.len += slice.len();
         debug_assert!(self.len <= self.cap);
@@ -356,9 +359,9 @@ impl FixedVec<u8> {
 impl<T> Drop for FixedVec<T> {
     fn drop(&mut self) {
         unsafe {
-            std::alloc::dealloc(
+            alloc::alloc::dealloc(
                 self.ptr.cast(),
-                std::alloc::Layout::array::<T>(self.cap).unwrap(),
+                alloc::alloc::Layout::array::<T>(self.cap).unwrap(),
             )
         }
     }
@@ -375,6 +378,7 @@ impl From<FixedVec<u8>> for String {
 mod tests {
     mod dot_atoms {
         use super::super::{ParseError, Parser};
+        use alloc::string::ToString;
 
         #[test]
         fn test_parse_local_part() {
@@ -457,6 +461,7 @@ mod tests {
     #[cfg(feature = "literals")]
     mod literals {
         use super::super::{ParseError, Parser};
+        use alloc::string::ToString;
 
         #[test]
         fn test_parse_literal_domain() {

--- a/src/unicode.rs
+++ b/src/unicode.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 #[cfg(feature = "normalization")]
 pub fn normalize<S>(value: S) -> String
 where


### PR DESCRIPTION
Reopens #1002 on a clean branch based on the current `main`, preserving @AverageHelper's original commits and authorship.

This replaces `std` reexports with `alloc`/`core`, disables dependency default features that pull in `std`, documents `no_std` support, and adds a CI cross-build for `thumbv6m-none-eabi`.

Validated locally with:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo build --release --target thumbv6m-none-eabi`
- `no_std` builds with no default features and with every compatible stable feature, including Serde

The optional `email_address` integration remains `std`-only because the upstream `email_address` crate does not support `no_std`.
