### PR TITLE
docs: credit Discussion authors in implementation PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ reviewed, so we agree on changes before writing code.
 
 If we decide to implement it, a Mathematic maintainer or authorized maintenance
 agent will open the pull request.
+When Mathematic implements a proposal, we will link the implementation pull
+request to the Discussion and credit the proposal's original author.
 
 ## Pull request policy
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ not yield the same `EmailAddress`.
 Start a [Discussion](../../discussions/new) before proposing a code change. A
 Mathematic maintainer will review the proposal there. If we decide to implement
 it, a maintainer or authorized maintenance agent will open the pull request.
+When Mathematic implements a proposal, we will link the implementation pull
+request to the Discussion and credit the proposal's original author.
 
 GitHub restricts pull request creation to Mathematic maintainers and repository
 collaborators with write, maintain, or admin access, plus authorized maintenance


### PR DESCRIPTION
## Summary

Promise to link accepted proposals from implementation PRs and credit each proposal author.

## Validation

- documentation scope check
- git diff --check