### PR TITLE
fix: use release-compatible Cargo dependency table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,12 @@ keywords = ["address", "email", "parser", "rfc2822", "rfc5322"]
 unicode-normalization = { version = "0.1.25", default-features = false, optional = true }
 
 email_address = { version = "0.2.9", default-features = false, optional = true }
-serde = {
-  version = "1.0.229",
-  default-features = false,
-  features = [
-    "alloc",
-    "derive",
-  ],
-  optional = true
-}
+
+[dependencies.serde]
+version = "1.0.229"
+default-features = false
+features = ["alloc", "derive"]
+optional = true
 
 [dev-dependencies]
 regex = "1.13.1"


### PR DESCRIPTION
Release Please cannot parse TOML 1.1 multiline inline tables, so the latest main release workflow fails while reading `Cargo.toml`. Express the same optional Serde dependency as a standard dependency table, which both Cargo and Release Please support.

Verification:
- `mise exec -- hk check --all --slow`
- `mise exec -- cargo test` (20 unit tests and 6 doc tests)