### PR TITLE
chore(deps): update rumdl to 0.2.61

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ jq = "1.8.2"
 lychee = "0.24.2"
 pinact = "4.1.1"
 python = "3.14.7"
-rumdl = "0.2.60"
+rumdl = "0.2.61"
 rust = { version = "1.98.0", profile = "minimal", components = [
   "clippy",
   "rustfmt",


### PR DESCRIPTION
Updates the pinned rumdl version to 0.2.61.

Validation:
- mise configuration parsed successfully
- mise exec -- hk check --all --slow