### PR TITLE
fix(ci): test stable feature set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
-      - name: Test
-        run: cargo test
+      - name: Test default features
+        run: cargo test --locked
+      - name: Test stable optional features
+        run: cargo test --locked --no-default-features --features comments,email_address,literals,normalization,serde,white-spaces
       - name: Test no_std build
         run: |
           rustup target add thumbv6m-none-eabi

--- a/hk.pkl
+++ b/hk.pkl
@@ -194,6 +194,13 @@ local checks = new Mapping<String, Step> {
     fix = null
     profiles = slow
   }
+  ["cargo-test-stable-features"] {
+    glob = rustFiles
+    workspace_indicator = null
+    check =
+      "cargo test --locked --no-default-features --features comments,email_address,literals,normalization,serde,white-spaces"
+    profiles = slow
+  }
   ["cargo-clippy"] = (Builtins.cargo_clippy) {
     glob = rustFiles
     workspace_indicator = null


### PR DESCRIPTION
Tests every stable optional feature together while excluding the nightly-only feature from stable Cargo invocations. The exhaustive hk profile and the primary CI workflow now both exercise comments, email_address, literals, normalization, serde, and white-spaces.

Validation:
- 43 unit tests and 6 doctests with the stable feature set
- mise exec -- hk check --all --slow