### PR TITLE
chore(hk): ignore changelog files

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -3,6 +3,7 @@ amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
 
 min_hk_version = "1.56.1"
+exclude = List("**/CHANGELOG.md")
 hide_warnings = List("missing-profiles")
 
 local generatedFiles =


### PR DESCRIPTION
Adds the native global hk exclusion for every CHANGELOG.md path.

Validation:
- hk check --slow CHANGELOG.md selected zero files
- mise exec -- hk check --all --slow