### PR TITLE
fix(msrv): declare Rust 1.81 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # stable
+        with:
+          toolchain: "1.81"
+      - name: Test stable optional features on the MSRV
+        run: cargo test --locked --all-targets --no-default-features --features comments,email_address,literals,normalization,serde,white-spaces
+
   ci:
     name: CI
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "addr-spec"
 version = "0.10.2"
 edition = "2021"
+rust-version = "1.81"
 description = "A wicked fast UTF-8 email address parser and serializer."
 license = "Apache-2.0"
 authors = ["Mathematic Inc"]


### PR DESCRIPTION
Declares the published crate's tested minimum Rust version and adds a dedicated exact-toolchain CI job for the locked, all-target stable-feature suite.

Validation:
- `rustup run 1.81.0 cargo test --locked --all-targets --no-default-features --features comments,email_address,literals,normalization,serde,white-spaces` (43 passed)
- `mise exec -- hk check --all --slow`
- `cargo package --locked --allow-dirty`